### PR TITLE
Fix bug in dynamics for stor.py

### DIFF
--- a/src/components/technologies/genericTechnologies/stor.py
+++ b/src/components/technologies/genericTechnologies/stor.py
@@ -568,9 +568,10 @@ class Stor(Technology):
                         )
 
                         def init_ramping_down_rate_operation_in(const):
-                            return -ramping_rate <= sum(
-                                self.input[t, car_input] - self.input[t - 1, car_input]
-                                for car_input in b_tec.set_input_carriers
+                            return (
+                                -ramping_rate
+                                <= self.input[t, self.main_car]
+                                - self.input[t - 1, self.main_car]
                             )
 
                         dis.const_ramping_down_rate_in = Constraint(
@@ -579,11 +580,8 @@ class Stor(Technology):
 
                         def init_ramping_up_rate_operation_in(const):
                             return (
-                                sum(
-                                    self.input[t, car_input]
-                                    - self.input[t - 1, car_input]
-                                    for car_input in b_tec.set_input_carriers
-                                )
+                                self.input[t, self.main_car]
+                                - self.input[t - 1, self.main_car]
                                 <= ramping_rate
                             )
 
@@ -642,9 +640,10 @@ class Stor(Technology):
 
             def init_ramping_down_rate_input(const, t):
                 if t > 1:
-                    return -ramping_rate <= sum(
-                        self.input[t, car_input] - self.input[t - 1, car_input]
-                        for car_input in b_tec.set_input_carriers
+                    return (
+                        -ramping_rate
+                        <= self.input[t, self.main_car]
+                        - self.input[t - 1, self.main_car]
                     )
                 else:
                     return Constraint.Skip
@@ -656,10 +655,7 @@ class Stor(Technology):
             def init_ramping_up_rate_input(const, t):
                 if t > 1:
                     return (
-                        sum(
-                            self.input[t, car_input] - self.input[t - 1, car_input]
-                            for car_input in b_tec.set_input_carriers
-                        )
+                        self.input[t, self.main_car] - self.input[t - 1, self.main_car]
                         <= ramping_rate
                     )
                 else:


### PR DESCRIPTION
for the input of the storage the RR only constrains the main input carrier. For the output nothing has changed.